### PR TITLE
feat: add seed functionality for our database data

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,23 @@ This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next
 
 ## Getting Started
 
-First, run the development server:
+### Install project dependencies
+
+```bash
+npm install
+```
+
+### Configure environment variables
+
+Create a .env
+
+```bash
+cp .env-template .env
+```
+
+In the `.env` file, fill in the variables that are need (i.e. db credentials, sendgrid keys, etc)
+
+### Run the development server:
 
 ```bash
 npm run dev

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,18 +1,25 @@
 import './drizzle/envConfig';
 import { defineConfig } from 'drizzle-kit';
+import postgres from 'postgres';
+import { drizzle } from 'drizzle-orm/postgres-js';
+
+const dbCredentials = {
+  host: process.env.POSTGRES_HOST!,
+  database: process.env.POSTGRES_DATABASE!,
+  port: Number(process.env.POSTGRES_PORT!),
+  user: process.env.POSTGRES_USER!,
+  password: process.env.POSTGRES_PASSWORD!,
+
+  /* NOTE: Alternative approach */
+  // url: process.env.POSTGRES_URL!,
+};
+
+const client = postgres(dbCredentials);
+export const db = drizzle(client);
 
 export default defineConfig({
   schema: './drizzle/schema.ts',
   out: './drizzle',
   dialect: 'postgresql',
-  dbCredentials: {
-    host: process.env.POSTGRES_HOST!,
-    database: process.env.POSTGRES_DATABASE!,
-    port: Number(process.env.POSTGRES_PORT!),
-    user: process.env.POSTGRES_USER!,
-    password: process.env.POSTGRES_PASSWORD!,
-
-    /* NOTE: Alternative approach */
-    // url: process.env.POSTGRES_URL!,
-  },
+  dbCredentials,
 });

--- a/drizzle/seed-data.ts
+++ b/drizzle/seed-data.ts
@@ -1,0 +1,10 @@
+// TODO: figure out how to assign types from the schema for consistency
+export const techqueria_org = {
+  name: 'Techqueria',
+  logo_url: '',
+  description: '',
+  industry: '',
+  website: 'https://techqueria.org/',
+  city: '',
+  region: '',
+};

--- a/drizzle/seed.ts
+++ b/drizzle/seed.ts
@@ -1,0 +1,21 @@
+import './envConfig';
+import { OrganizationContacts, OrganizationsTable } from './schema';
+import { db } from '../drizzle.config';
+import { techqueria_org } from './seed-data';
+
+async function main() {
+  try {
+    console.log('Seed started...');
+
+    await db.insert(OrganizationsTable).values([techqueria_org]);
+    // TODO: insert proper seed data into tables
+
+    console.log('Seed finished...');
+  } catch (e) {
+    console.error(e);
+    throw new Error('Seed error...');
+  }
+
+  process.exit(0);
+}
+main();

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "next start",
     "lint": "next lint",
     "migration:generate": "drizzle-kit generate",
-    "migration:apply": "drizzle-kit migrate"
+    "migration:apply": "drizzle-kit migrate",
+    "db:seed": "npx tsx ./drizzle/seed.ts"
   },
   "dependencies": {
     "@next/env": "^14.2.5",


### PR DESCRIPTION
Ticket: https://app.asana.com/0/1207992233793749/1208069710371317/f

This seed functionality is run outside of the next.js application. Running the seed script will allow us to use the same data across our different developer environments.

It's an initial implementation and needs further work.

TODO:
- Add contacts and events examples
- Prevent over-seeding. currently continues to add rows even if the data exists.
